### PR TITLE
Fixed cpk path

### DIFF
--- a/Mod.cs
+++ b/Mod.cs
@@ -100,7 +100,7 @@ public partial class Mod : ModBase // <= Do not Remove.
                 _logger.Error("Unable to load CriFS V2 Library Hooks!");
                 return;
             }
-            else criFsApi.AddProbingPath("MFEssentials");
+            else criFsApi.AddProbingPath("MFEssentials/CPK");
 
             _criFsApi.AddBindCallback(OnBindMFR);
             // Metaphor ReFantazio only has 1 CPK


### PR DESCRIPTION
Mods weren't working after following your instructions. I seems that crifs.v2.hook and p5ressentials search on <name>/CPK while this one just searched on <name>

Compiled it and seems to be working now.

Thank you for your great work!